### PR TITLE
Add global scroll-to-top button

### DIFF
--- a/arcup-astro/src/components/ScrollToTop.astro
+++ b/arcup-astro/src/components/ScrollToTop.astro
@@ -1,0 +1,91 @@
+---
+const threshold = 240;
+---
+<button class="scroll-to-top" aria-label="Scroll back to top">
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    width="20"
+    height="20"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path d="M12 19V5" />
+    <polyline points="5 12 12 5 19 12" />
+  </svg>
+</button>
+<script is:inline>
+  const button = document.currentScript?.previousElementSibling;
+  if (button) {
+    const toggle = () => {
+      if (window.scrollY > threshold) {
+        button.classList.add("is-visible");
+      } else {
+        button.classList.remove("is-visible");
+      }
+    };
+
+    window.addEventListener("scroll", toggle, { passive: true });
+    toggle();
+
+    button.addEventListener("click", () => {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    });
+  }
+</script>
+<style>
+  .scroll-to-top {
+    position: fixed;
+    right: clamp(1.25rem, 3vw, 2rem);
+    bottom: clamp(1.5rem, 4vw, 2.5rem);
+    width: 3.25rem;
+    height: 3.25rem;
+    z-index: 50;
+    border-radius: 999px;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(241, 245, 249, 0.85);
+    background: radial-gradient(120% 120% at 30% 30%, rgba(93, 225, 228, 0.25), transparent 70%),
+      rgba(4, 8, 16, 0.82);
+    box-shadow: 0 18px 45px -30px rgba(93, 225, 228, 0.55), 0 0 20px rgba(93, 225, 228, 0.2);
+    transition: opacity var(--transition-base), transform var(--transition-base),
+      box-shadow var(--transition-base);
+    opacity: 0;
+    transform: translateY(12px);
+    pointer-events: none;
+    backdrop-filter: blur(12px);
+  }
+
+  .scroll-to-top svg {
+    transform: translateY(-1px);
+  }
+
+  .scroll-to-top:is(:hover, :focus-visible) {
+    box-shadow: 0 24px 55px -28px rgba(93, 225, 228, 0.7), 0 0 25px rgba(93, 225, 228, 0.28);
+    color: var(--color-text);
+  }
+
+  .scroll-to-top.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .scroll-to-top {
+      transition: opacity 120ms ease;
+    }
+
+    .scroll-to-top,
+    .scroll-to-top.is-visible {
+      transform: none;
+    }
+  }
+</style>

--- a/arcup-astro/src/layouts/BaseLayout.astro
+++ b/arcup-astro/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import ScrollToTop from "../components/ScrollToTop.astro";
 
 const {
   title = "arc^ byali",
@@ -62,6 +63,7 @@ const bodyClasses = ["site-body", bodyClass].filter(Boolean).join(" ");
   </head>
   <body class={bodyClasses}>
     <slot />
+    <ScrollToTop />
     <slot name="scripts" />
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a reusable ScrollToTop Astro component that reveals a floating button after scrolling
- include the component in the base layout so it appears on every page
- style the control to match the site's aesthetic while respecting reduced motion preferences

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db935fa9fc8330a3bebd6ab8e33480